### PR TITLE
MCAL_RTE_changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+CC = gcc
+CFLAGS = -Wall -Wextra -Iinclude -Isrc/mcal -Isrc/rte
+SRCS = src/mcal/CanDriver.c src/rte/Rte_CanIf.c src/main.c
+OBJS = $(SRCS:.c=.o)
+TARGET = complex_driver_demo
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f $(OBJS) $(TARGET)

--- a/include/CanIf_Types.h
+++ b/include/CanIf_Types.h
@@ -1,0 +1,18 @@
+#ifndef CANIF_TYPES_H
+#define CANIF_TYPES_H
+
+#include "Std_Types.h"
+
+#define CANIF_MAX_DATA_LEN 8
+#define CANIF_MAX_MB       32
+
+typedef struct {
+    uint32_t id;
+    uint8_t  length;
+    uint8_t  data[CANIF_MAX_DATA_LEN];
+} CanIf_PduType;
+
+typedef void (*CanIf_RxIndicationType)(const CanIf_PduType* pdu);
+typedef void (*CanIf_TxConfirmationType)(uint8_t mb);
+
+#endif // CANIF_TYPES_H

--- a/include/Std_Types.h
+++ b/include/Std_Types.h
@@ -1,0 +1,10 @@
+#ifndef STD_TYPES_H
+#define STD_TYPES_H
+
+#include <stdint.h>
+
+typedef uint8_t Std_ReturnType;
+#define E_OK    0x00
+#define E_NOT_OK 0x01
+
+#endif // STD_TYPES_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,23 @@
+#include "Rte_CanIf.h"
 #include <stdio.h>
-#include "uds_services.h"
+#include <unistd.h> // for sleep, if on Linux
 
-int main() {
-    uds_handle_request(0x10, NULL);  // Example: Start session
+int main(void) {
+    Rte_Init();
+
+    CanIf_PduType pduTx = { .id = 0x200, .length = 8, .data = {10,20,30,40,50,60,70,80} };
+    if (Rte_CanIf_Transmit(1, &pduTx) == 0) {
+        printf("[APP] Transmit requested successfully.\n");
+    } else {
+        printf("[APP] Transmit request failed.\n");
+    }
+
+    // Simulate periodic tasks
+    for (int i = 0; i < 5; i++) {
+        Can_MainFunctionTx();
+        Can_MainFunctionRx();
+        sleep(1);  // Wait 1 sec (simulate time passing)
+    }
+
     return 0;
 }

--- a/src/mcal/CanDriver.c
+++ b/src/mcal/CanDriver.c
@@ -1,0 +1,67 @@
+#include "CanDriver.h"
+#include "Mcal_Cfg.h"
+#include <string.h> // for memcpy
+#include <stdio.h>  // for simulation printf
+
+static CanMbxType Can_Mailboxes[CAN_MCAL_MAX_MB];
+
+static CanIf_RxIndicationType RxIndicationCb = NULL;
+static CanIf_TxConfirmationType TxConfirmationCb = NULL;
+
+void Can_SetRxIndicationCallback(CanIf_RxIndicationType cb) {
+    RxIndicationCb = cb;
+}
+
+void Can_SetTxConfirmationCallback(CanIf_TxConfirmationType cb) {
+    TxConfirmationCb = cb;
+}
+
+void Can_Init(void) {
+    for (int i = 0; i < CAN_MCAL_MAX_MB; i++) {
+        Can_Mailboxes[i].state = CAN_MBX_IDLE;
+    }
+    printf("[MCAL] CAN initialized with %d mailboxes at %d baud.\n", CAN_MCAL_MAX_MB, CAN_MCAL_BAUDRATE);
+}
+
+Std_ReturnType Can_Write(uint8_t mb, const CanIf_PduType* pdu) {
+    if (mb >= CAN_MCAL_MAX_MB) {
+        return E_NOT_OK;
+    }
+    if (Can_Mailboxes[mb].state == CAN_MBX_IDLE) {
+        memcpy(&Can_Mailboxes[mb].pdu, pdu, sizeof(CanIf_PduType));
+        Can_Mailboxes[mb].state = CAN_MBX_TX_PENDING;
+        printf("[MCAL] CAN Write requested on MB %d with ID 0x%X\n", mb, pdu->id);
+        return E_OK;
+    }
+    return E_NOT_OK; // mailbox busy
+}
+
+void Can_MainFunctionTx(void) {
+    for (int i = 0; i < CAN_MCAL_MAX_MB; i++) {
+        if (Can_Mailboxes[i].state == CAN_MBX_TX_PENDING) {
+            // Simulate transmission success
+            Can_Mailboxes[i].state = CAN_MBX_TX_CONFIRMED;
+            printf("[MCAL] CAN Transmission confirmed on MB %d\n", i);
+
+            if (TxConfirmationCb) {
+                TxConfirmationCb(i);
+            }
+            // Reset mailbox after confirmation
+            Can_Mailboxes[i].state = CAN_MBX_IDLE;
+        }
+    }
+}
+
+void Can_MainFunctionRx(void) {
+    // Simulate receiving a CAN frame in mailbox 0 (for demo)
+    static int toggle = 0;
+    if (toggle == 0) {
+        CanIf_PduType rxPdu = { .id = 0x100, .length = 8, .data = {0,1,2,3,4,5,6,7} };
+        printf("[MCAL] CAN Received frame ID 0x%X\n", rxPdu.id);
+
+        if (RxIndicationCb) {
+            RxIndicationCb(&rxPdu);
+        }
+    }
+    toggle = !toggle;
+}

--- a/src/mcal/CanDriver.h
+++ b/src/mcal/CanDriver.h
@@ -1,0 +1,27 @@
+#ifndef CAN_DRIVER_H
+#define CAN_DRIVER_H
+
+#include "CanIf_Types.h"
+#include "Std_Types.h"
+
+typedef enum {
+    CAN_MBX_IDLE = 0,
+    CAN_MBX_TX_PENDING,
+    CAN_MBX_TX_CONFIRMED,
+    CAN_MBX_RX_READY
+} CanMbx_StateType;
+
+typedef struct {
+    CanMbx_StateType state;
+    CanIf_PduType   pdu;
+} CanMbxType;
+
+void Can_Init(void);
+Std_ReturnType Can_Write(uint8_t mb, const CanIf_PduType* pdu);
+void Can_MainFunctionTx(void);
+void Can_MainFunctionRx(void);
+
+void Can_SetRxIndicationCallback(CanIf_RxIndicationType cb);
+void Can_SetTxConfirmationCallback(CanIf_TxConfirmationType cb);
+
+#endif // CAN_DRIVER_H

--- a/src/mcal/Mcal_Cfg.h
+++ b/src/mcal/Mcal_Cfg.h
@@ -1,0 +1,7 @@
+#ifndef MCAL_CFG_H
+#define MCAL_CFG_H
+
+#define CAN_MCAL_MAX_MB 32
+#define CAN_MCAL_BAUDRATE 500000
+
+#endif // MCAL_CFG_H

--- a/src/rte/Rte_CanIf.c
+++ b/src/rte/Rte_CanIf.c
@@ -1,0 +1,32 @@
+#include "Rte_CanIf.h"
+#include "CanDriver.h"
+#include <stdio.h>
+
+static void OnRxIndication(const CanIf_PduType* pdu) {
+    printf("[RTE] RxIndication received ID 0x%X, length %d\n", pdu->id, pdu->length);
+    // Further processing or signal routing here
+}
+
+static void OnTxConfirmation(uint8_t mb) {
+    printf("[RTE] TxConfirmation received for MB %d\n", mb);
+    // Further processing or signal routing here
+}
+
+Std_ReturnType Rte_CanIf_Transmit(uint8_t mb, const CanIf_PduType* pdu) {
+    return Can_Write(mb, pdu);
+}
+
+void Rte_CanIf_RxIndication(const CanIf_PduType* pdu) {
+    OnRxIndication(pdu);
+}
+
+void Rte_CanIf_TxConfirmation(uint8_t mb) {
+    OnTxConfirmation(mb);
+}
+
+void Rte_Init(void) {
+    Can_Init();
+    Can_SetRxIndicationCallback(Rte_CanIf_RxIndication);
+    Can_SetTxConfirmationCallback(Rte_CanIf_TxConfirmation);
+    printf("[RTE] Initialized and callbacks set.\n");
+}

--- a/src/rte/Rte_CanIf.h
+++ b/src/rte/Rte_CanIf.h
@@ -1,0 +1,13 @@
+#ifndef RTE_CANIF_H
+#define RTE_CANIF_H
+
+#include "CanIf_Types.h"
+#include "Std_Types.h"
+
+Std_ReturnType Rte_CanIf_Transmit(uint8_t mb, const CanIf_PduType* pdu);
+void Rte_CanIf_RxIndication(const CanIf_PduType* pdu);
+void Rte_CanIf_TxConfirmation(uint8_t mb);
+
+void Rte_Init(void);
+
+#endif // RTE_CANIF_H


### PR DESCRIPTION
MCAL driver CanDriver.c manages TX/RX mailboxes, simulates interrupts.

RTE layer wraps MCAL driver, handles callback routing.

main.c shows example usage with transmission and reception.

Makefile to build the example on Linux (gcc).